### PR TITLE
Allow format=2 in api request

### DIFF
--- a/src/Controller/ForecastController.php
+++ b/src/Controller/ForecastController.php
@@ -33,6 +33,10 @@ class ForecastController extends AbstractController
             return new Response($weather);
         }
 
+        if ($format && $format == 2) { //lets return the same content for format 2 as we don't know the changes
+            return new Response($weather);
+        }
+
         throw $this->createNotFoundException();
     }
 }


### PR DESCRIPTION
In the latest update, loxone is requesting format=2 from the weather service. We don't know the changes but returning the same format as 1 seems to work.